### PR TITLE
Build single-file executables for Windows, Linux and MacOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ dist/
 .DS_Store
 in.mp4
 out.mp4
+/build

--- a/build-binary.js
+++ b/build-binary.js
@@ -1,0 +1,30 @@
+import * as child_process from "node:child_process";
+import * as fs from "node:fs";
+import { zip } from "zip-a-folder";
+
+// Load the package.json file
+let packageJSON = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+let cmdName = packageJSON.name;
+let version = packageJSON.version;
+
+child_process.execSync("bun run build");
+
+let platforms = [
+    "bun-linux-x64-baseline",
+    "bun-macos-x64-baseline",
+    "bun-windows-x64-baseline"
+];
+
+for (let platform of platforms) {
+    let os = platform.split("-")[1];
+    let dir = `./build/${cmdName}-${version}-${os}`;
+    let outputFilename = `${dir}/${cmdName}`;
+    let zipFilename = `./build/${cmdName}-${version}-${os}.zip`;
+
+    child_process.execSync(`bun build ./dist/cli.js --compile --minify --target=${platform} --outfile ${outputFilename}`);
+    await zip(dir, zipFilename);
+
+    console.log(`Created ${zipFilename}`);
+}
+
+

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "test": "tsc --noEmit",
     "clean": "rimraf dist",
     "build": "rimraf dist && tsc -p . && rimraf dist/tsconfig.tsbuildinfo",
-    "tsc": "tsc -p ."
+    "tsc": "tsc -p .",
+    "build-binary": "bun build-binary.js"
   },
   "dependencies": {
     "@beenotung/tslib": "^23.11.1",
@@ -49,6 +50,7 @@
     "rimraf": "^6.0.1",
     "ts-node": "^10.9.2",
     "ts-node-dev": "^2.0.0",
-    "typescript": "^5.5.4"
+    "typescript": "^5.5.4",
+    "zip-a-folder": "^3.1.7"
   }
 }


### PR DESCRIPTION
Just saw your project on HKITHUB. And I think it would be nice to provide a single binary for someone who doesn't have Node.js. 

I also would like to find something to test "bun build --compile".

You can see my build here:
https://github.com/louislam/silentremove-ffmpeg/releases/tag/1.0.1
![image](https://github.com/user-attachments/assets/dec443c7-0e76-4a26-8e5b-30058aca5888)

Tested on Windows, it is working fine:
![image](https://github.com/user-attachments/assets/ac2628d6-ae1c-40ee-83b5-793b378d035b)

Further improvements:
- GitHub Workflow auto build and auto release
- Add arm64 build

Reference:
https://bun.sh/docs/bundler/executables